### PR TITLE
CSS fix for Trac v1.0.1

### DIFF
--- a/htdocs/css/patch.css
+++ b/htdocs/css/patch.css
@@ -15,7 +15,7 @@ textarea {
     border-right: 0;
     display: list-item;
     padding: 0;
-    white-space: nowrap;
+    white-space: normal;
 }
 
 .navbar .nav > li > a {


### PR DESCRIPTION
Modified htdocs/css/patch.css. Changed in rule .nav li whitespace: nowrap; to whitespace: normal;

Fixes navbar text overflow in Trac v1.0.1
